### PR TITLE
Added alternate GH Pages action

### DIFF
--- a/.github/workflows/github-pages-alt.yml
+++ b/.github/workflows/github-pages-alt.yml
@@ -1,0 +1,51 @@
+name: "Deploy Jekyll site to GitHub Pages (aftermarket Jekyll Action)"
+
+on:
+  gollum:
+
+  push:
+    branches:
+      - "$default-branch"
+      - develop
+
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+      - unlabeled
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. However, do NOT cancel in-progress runs as
+# we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+
+  ##
+  # Builds & deploys the Jekyll site to GitHub Pages.
+  #
+  # See: https://github.com/helaili/jekyll-action
+  #
+  github-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Enable caching of Ruby gems
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - uses: helaili/jekyll-action@2.0.5    # Choose any one of the Jekyll Actions
+        with:                                # Some relative inputs of your action
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,14 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 
-
+# Jekyll plugins are loaded right after jekyll itself so any plugin that
+# adds a new command, overrides a default Jekyll class or modifies liquid
+# tags/filters must be listed here.
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-timeago', '~> 0.13.1'
-
-  # Use unreleased minima v3 theme
-  # See: https://github.com/jekyll/minima/tree/2863624b903b17f838d6ce8d2f77900fa9d3c864#readme
-  gem "minima", git: 'https://github.com/jekyll/minima.git', ref: '2863624b90'
 end
+
+# Use unreleased minima v3 theme
+# See: https://github.com/jekyll/minima/tree/2863624b903b17f838d6ce8d2f77900fa9d3c864#readme
+gem "minima", git: 'https://github.com/jekyll/minima.git', ref: '2863624b90'

--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,14 @@
 
 title: '"I ❤️ building teams" - Delano Mandelbaum'
 
-author:
-  name: Delano Mandelbaum
-  email: "delano@onetimesecret.com"
+# Minima 3.0
+# author:
+#   name: Delano Mandelbaum
+#   email: "delano@onetimesecret.com"
+
+# Minima 2.5 (legacy)
+author: Delano
+email: delano@onetimesecret.com
 
 url: "https://delanotes.com"
 baseurl: ""


### PR DESCRIPTION
Follow-up for PR #12.

This new action based on [helaili/jekyll-action](https://github.com/helaili/jekyll-action) could correct the issue where minima is installed via gem instead of git.