### PR TITLE
Use modified minima to resolve GH Action build error

### DIFF
--- a/.github/workflows/github-pages-alt.yml
+++ b/.github/workflows/github-pages-alt.yml
@@ -42,9 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: |
-          sudo gem install rubygems-update --no-document -v 3.4
-
       # Enable caching of Ruby gems
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/github-pages-alt.yml
+++ b/.github/workflows/github-pages-alt.yml
@@ -50,8 +50,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - uses: helaili/jekyll-action@2.5.0    # Choose any one of the Jekyll Actions
-        with:                                # Some relative inputs of your action
+      - uses: delano/jekyll-action@2.5.0-dev    # Choose any one of the Jekyll Actions
+        with:                                   # Some relative inputs of your action
           keep_history: true
           token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gem "rubygems-update", "~> 3.4"
-
 gem "jekyll", "~> 4.3"
 
 # Jekyll plugins are loaded right after jekyll itself so any plugin that
@@ -14,4 +12,4 @@ end
 
 # Use unreleased minima v3 theme
 # See: https://github.com/jekyll/minima/tree/2863624b903b17f838d6ce8d2f77900fa9d3c864#readme
-gem "minima", git: 'https://github.com/jekyll/minima.git', ref: '2863624b90'
+gem "minima", git: 'https://github.com/delano/minima.git', branch: 'hotfix/v3-sass-rubygems'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ group :jekyll_plugins do
   gem 'jekyll-timeago', '~> 0.13.1'
 end
 
-# Use unreleased minima v3 theme
-# See: https://github.com/jekyll/minima/tree/2863624b903b17f838d6ce8d2f77900fa9d3c864#readme
+# Use unreleased minima v3 theme from our own fork with a fix for RubyGems
+# See v3: https://github.com/jekyll/minima/tree/2863624b903b17f838d6ce8d2f77900fa9d3c864#readme
 gem "minima", git: 'https://github.com/delano/minima.git', branch: 'hotfix/v3-sass-rubygems'


### PR DESCRIPTION
### Changes
- Removed explicit rubygems update in workflow
- Install minima from our own fork. 


### Additional context

Build error:

```
Starting the Jekyll Action
Remote branch is main
Cloning into '.'...
Fetching https://github.com/jekyll/minima.git
Fetching gem metadata from https://rubygems.org/............
Fetching gem metadata from [https://rubygems.org/.](https://rubygems.org/)
Resolving dependencies...
sass-embedded-1.62.0-x86_64-linux-musl requires rubygems version >= 3.3.22,
which is incompatible with the current version, 3.1.6
```